### PR TITLE
update nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "~2.4.0"
+    "nan": "~2.10.0"
   }
 }


### PR DESCRIPTION
nan 2.4.0 fails to build with Node 10, because v8::Object#ForceSet has been removed.